### PR TITLE
Fix Build Process

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,11 +37,17 @@ Read more about the components from the upstream template by Microsoft [here](ht
         - ` $ cd Pengwin`
         - ` $ chmod u+x create-targz-x64.sh`
         - ` $ ./create-targz-x64.sh`
-    1. You should find an install.tar.gz in the /x64/ directory of your build directory. (When we get ARM64 support working there will also be an install.tar.gz in a /ARM64/ directory.)
+    1. You should find an install.tar.gz in the /x64/ directory of your build directory.
+        - If you are targeting ARM64, you'll also need repeat the last two steps for `create-targz-arm64.sh`.
 1. Build the solution to make sure you have everything you need. Fix any build dependencies you are missing.
 1. Build the Windows UWP package:
     1. Open a `Developer Command Prompt for VS 2019` as an administrator and change directory to your build directory.
     1. Run `build.bat`
+        - By default, this generates the debug appxbundle targeting both x64 and ARM64
+        - To only target Debug|x64, run `built.bat x64`
+        - To only target Debug|ARM64 run `build.bat ARM64`
+        - To build Releases instead of Debug appxbundles, include the `rel` option (e.g. `build.bat rel`, `build.bat rel x64`)
+        - For a clean build, include the `clean` option (e.g. `build.bat clean`, `build.bat clean rel ARM64`)
 
 1. If everything has gone correctly, you should find your app package in a subfolder under the `AppPackages\DistroLauncher-Appx` folder.
     1. First, install the certificate:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,13 +41,18 @@ Read more about the components from the upstream template by Microsoft [here](ht
         - If you are targeting ARM64, you'll also need repeat the last two steps for `create-targz-arm64.sh`.
 1. Build the solution to make sure you have everything you need. Fix any build dependencies you are missing.
 1. Build the Windows UWP package:
-    1. Open a `Developer Command Prompt for VS 2019` as an administrator and change directory to your build directory.
-    1. Run `build.bat`
-        - By default, this generates the debug appxbundle targeting both x64 and ARM64
-        - To only target Debug|x64, run `built.bat x64`
-        - To only target Debug|ARM64 run `build.bat ARM64`
-        - To build Releases instead of Debug appxbundles, include the `rel` option (e.g. `build.bat rel`, `build.bat rel x64`)
-        - For a clean build, include the `clean` option (e.g. `build.bat clean`, `build.bat clean rel ARM64`)
+    The package can be built in Visual Studio or via command line
+    - For a UI guided build
+        1. Open `DistroLauncher.sln` in Visual Studio Community 2019.
+        1. Follow the instructions [here](https://docs.microsoft.com/en-us/windows/uwp/packaging/packaging-uwp-apps#create-an-app-package-upload-file)
+    - To build from the command line
+        1. Open a `Developer Command Prompt for VS 2019` as an administrator and change directory to your build directory.
+        1. Run `build.bat`
+            - By default, this generates the debug appxbundle targeting both x64 and ARM64
+            - To only target Debug|x64, run `built.bat x64`
+            - To only target Debug|ARM64 run `build.bat ARM64`
+            - To build Releases instead of Debug appxbundles, include the `rel` option (e.g. `build.bat rel`, `build.bat rel x64`)
+            - For a clean build, include the `clean` option (e.g. `build.bat clean`, `build.bat clean rel ARM64`)
 
 1. If everything has gone correctly, you should find your app package in a subfolder under the `AppPackages\DistroLauncher-Appx` folder.
     1. First, install the certificate:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,10 +7,10 @@
 Read more about the components from the upstream template by Microsoft [here](https://github.com/Microsoft/WSL-DistroLauncher). 
 
 ## Building Requirements
-1. [Visual Studio Community 2017](https://visualstudio.microsoft.com/vs/community/). (Free)
+1. [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/community/). (Free)
 	- The "Universal Windows Platform development" Workload is required, along with the following Individual components:
-		- `C++ Universal Windows Platform tools`
-		- `Windows 10 SDK (10.0.15063.0) for UWP: C#, VB, JS`
+		- `C++ (v142) Universal Windows Platform tools`
+		- `Windows 10 SDK (10.0.17134.0) for UWP: C#, VB, JS`
 1. Developer Mode
 	- Windows 10 must be in Developer mode, which can be enabled in Start -> Settings -> Update & Security -> For developers.
 1. Enable WSL
@@ -19,7 +19,7 @@ Read more about the components from the upstream template by Microsoft [here](ht
         - Open PowerShell as Administrator, type `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`, and restart as required.
 
 ## Build Process
-1. Open DistroLauncher.sln in Visual Studio Community 2017.
+1. Open DistroLauncher.sln in Visual Studio Community 2019.
 2. Generate a test certificate:
     1. In the Solution Explorer, open `DistroLauncher-Appx\MyDistro.appxmanifest`
     1. Select the Packaging tab

--- a/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{f63472f9-d0a0-412e-aa3d-a4e822970486}</ProjectGuid>
@@ -82,7 +82,7 @@
     <AppxBundlePlatforms>x64|arm64</AppxBundlePlatforms>
     <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
-    <AppxPackageDir>C:\Users\Hayden\OneDrive\Desktop\</AppxPackageDir>
+    <AppxPackageDir>$(SolutionDir)AppPackages\$(MSBuildProjectName)\</AppxPackageDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>

--- a/build.bat
+++ b/build.bat
@@ -109,7 +109,7 @@ goto :ARGS_LOOP
 
 if (%ERRORLEVEL%) == (0) (
     echo.
-    echo Created appx in %~dp0x64\%_MSBUILD_CONFIG%\DistroLauncher-Appx\
+    echo Created appx in %~dp0AppPackages\DistroLauncher-Appx\
     echo.
 )
 

--- a/build.bat
+++ b/build.bat
@@ -38,24 +38,24 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Curre
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe"
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2019\Community\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" (
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2019\Professional\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe" (
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2019\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" (

--- a/build.bat
+++ b/build.bat
@@ -93,7 +93,7 @@ if (%1) == (x64) (
     set _MSBUILD_PLATFORM=x64
     set _MSBUILD_APPX_BUNDLE_PLATFORMS=x64
 )
-if (%1) == (arm64) (
+if (%1) == (ARM64) (
     set _MSBUILD_PLATFORM=ARM64
     set _MSBUILD_APPX_BUNDLE_PLATFORMS=ARM64
 )

--- a/build.bat
+++ b/build.bat
@@ -78,6 +78,8 @@ if %MSBUILD%==() (
 :FOUND_MSBUILD
 set _MSBUILD_TARGET=Build
 set _MSBUILD_CONFIG=Debug
+set _MSBUILD_PLATFORM=x64
+set _MSBUILD_APPX_BUNDLE_PLATFORMS="x64|ARM64"
 
 :ARGS_LOOP
 if (%1) == () goto :POST_ARGS_LOOP
@@ -87,11 +89,23 @@ if (%1) == (clean) (
 if (%1) == (rel) (
     set _MSBUILD_CONFIG=Release
 )
+if (%1) == (x64) (
+    set _MSBUILD_PLATFORM=x64
+    set _MSBUILD_APPX_BUNDLE_PLATFORMS=x64
+)
+if (%1) == (arm64) (
+    set _MSBUILD_PLATFORM=ARM64
+    set _MSBUILD_APPX_BUNDLE_PLATFORMS=ARM64
+)
 shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-%MSBUILD% %~dp0\DistroLauncher.sln /t:%_MSBUILD_TARGET% /m /nr:true /p:Configuration=%_MSBUILD_CONFIG%
+%MSBUILD% %~dp0\DistroLauncher.sln /t:%_MSBUILD_TARGET% /m /nr:true ^
+    /p:Configuration=%_MSBUILD_CONFIG% ^
+    /p:Platform=%_MSBUILD_PLATFORM% ^
+    /p:AppxBundlePlatforms=%_MSBUILD_APPX_BUNDLE_PLATFORMS% ^
+    /p:UseSubFolderForOutputDirDuringMultiPlatformBuild=false
 
 if (%ERRORLEVEL%) == (0) (
     echo.

--- a/build.bat
+++ b/build.bat
@@ -38,6 +38,30 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Curre
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe"
     goto :FOUND_MSBUILD
 )
+if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" (
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe" (
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
+	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" (
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
+    goto :FOUND_MSBUILD
+)
 if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" (
     set MSBUILD="%ProgramFiles(x86)%\MSBuild\14.0\bin\msbuild.exe"
     goto :FOUND_MSBUILD
@@ -67,7 +91,7 @@ shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-%MSBUILD% %~dp0\DistroLauncher.sln /t:%_MSBUILD_TARGET% /m /nr:true /p:Configuration=%_MSBUILD_CONFIG%;Platform=x64
+%MSBUILD% %~dp0\DistroLauncher.sln /t:%_MSBUILD_TARGET% /m /nr:true /p:Configuration=%_MSBUILD_CONFIG%
 
 if (%ERRORLEVEL%) == (0) (
     echo.


### PR DESCRIPTION
### Overview
This is a quality of life PR for the build process. It aims to make it easier to build from source.

### Issues Addressed
- Fixes #275 by adding explicit x64, ARM64 options to build.bat
- Fixes x64|ARM64 build w/ build.bat such that it is no longer necessarily to manually move files around for the build to succeed.
- Adds support for msbuild.exe provided by Visual Studio 2019 editions
- Fixes regression regarding output directory, mentioned in issues #53 and #70 and previously addressed in 5e7256ff2047e4b7060eabb8f41ac579c7238cbb and reintroduced in ab558d250652a150ef7b3883898e342872acf8c1; remapped to match path described in BUILDING.md

### Improved documentation
- Documented new x64, ARM64 build.bat options
- Updated documentation to reflect rebase in #411 
- Documented how to build from within Visual Studio
