### PR TITLE
resolve #771

### DIFF
--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -30,27 +30,27 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>

--- a/LauncherTests/LauncherTests.vcxproj
+++ b/LauncherTests/LauncherTests.vcxproj
@@ -16,7 +16,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/PengwinW/PengwinW.vcxproj
+++ b/PengwinW/PengwinW.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
@@ -41,7 +41,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/build.bat
+++ b/build.bat
@@ -102,6 +102,7 @@ goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
 %MSBUILD% %~dp0\DistroLauncher.sln /t:%_MSBUILD_TARGET% /m /nr:true ^
+	/restore ^
     /p:Configuration=%_MSBUILD_CONFIG% ^
     /p:Platform=%_MSBUILD_PLATFORM% ^
     /p:AppxBundlePlatforms=%_MSBUILD_APPX_BUNDLE_PLATFORMS% ^
@@ -109,7 +110,7 @@ goto :ARGS_LOOP
 
 if (%ERRORLEVEL%) == (0) (
     echo.
-    echo Created appx in %~dp0AppPackages\DistroLauncher-Appx\
+    echo Created MSIXBUNDLE in ./Pengwin/AppPackages/Pengwin_<version>_<arch>
     echo.
 )
 


### PR DESCRIPTION
This PR resolves issue #771, which is ultimately the result of multiple independent issues related to building.

Because there are a couple different ways to resolve the issues I encountered, there's room for discussion on exactly how fixes should be implemented upstream. I'll try to reference specific issues and pertinent details in this PR and then update BUILDING.md in a subsequent commit to document/reflect the agreed on changes to what the build process should look like.

First and foremost are the changes proposed in https://github.com/WhitewaterFoundry/legacy-rootfs-build-scripts/pull/1 -- getting pengwin-base built successfully first is critical. Some changes were needed so the script would continue to work as intended. As proposed, it is intended to work with the linux_files/setup file already in this repository instead of the one in the legacy-rootfs-build-scripts. Alternatively, perhaps one of the non-legacy scripts in https://github.com/WhitewaterFoundry/pengwin-rootfs-builds can referenced in build docs and used instead.

The next major issue is dependencies and the VS build environment. Current documentation recommends VS 2019, but platform tools v143 is not compatible/available on VS 2019. See the changes to .vcxproj files.

Past that, I encountered extensive NuGet dependency issues that were ultimately resolved by the changes made to build.bat to automatically restore dependencies. Other issues that were resolved without changes to specific scripts were where to modify the package thumbprint and exact steps related to trusting the signing certificate before the msixbundle is allowed to be installed.
